### PR TITLE
Fix Sundry reference name clipboard copy

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -8,6 +8,7 @@ v2.3.4 (08/##/2026)
 - FIX: Exp/hr pasting party recognizing their class (missionary and witchunter usually)  
 - FIX: Exp/hr pasting party and inventory/mana/spellcasting going to the wrong characters  
 - FIX: Paste Character treating item stat bonuses as part of your base stats  
+- FIX: "Copy Name to Clipboard" now works when right-clicking a reference on the Sundry tab  
 
 v2.3.3 (07/15/2026)  
 ------------------------------------------------------------------------------------  

--- a/frmMain.frm
+++ b/frmMain.frm
@@ -34285,7 +34285,7 @@ Select Case Index
         Select Case objWorkingListView.name
             Case "lvClasses", "lvRaces", "lvShopDetail", "lvSpellBook", "lvMapLoc", "lvSpellLoc", "lvShopLoc", "lvSpellCompareLoc":
                 Call CopyLVLinetoClipboard(objWorkingListView, , , , True)
-            Case "lvWeaponLoc", "lvArmourLoc", "lvSpellLoc", "lvShopLoc", "lvItemManagerLoc", "lvWeaponCompareLoc", "lvArmourCompareLoc":
+            Case "lvWeaponLoc", "lvArmourLoc", "lvSpellLoc", "lvShopLoc", "lvItemManagerLoc", "lvWeaponCompareLoc", "lvArmourCompareLoc", "lvOtherItemLoc":
                 Call CopyLVLinetoClipboard(objWorkingListView, , , 0, True)
             Case "lvShops":
                 Call CopyShopToClipboard(True)


### PR DESCRIPTION
Adds `lvOtherItemLoc` to the right-click copy handler in `frmMain` so "Copy Name to Clipboard" works for Sundry tab references. Updates the changelog entry for v2.3.4 to document the fix.