### PR TITLE
Refactor item quantity handling and improve UI interactions

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -3,12 +3,14 @@ v2.3.4 (08/##/2026)
 - UP: Monsters will no longer show the combined lair HP in the column/table when in lair mode  
 - UP: Armour AC/DR column now alternates between sorting by AC and by DR on repeated clicks  
 - UP: New toggle option in menu to initially always show shops first when listing item references  
+- UP: Item Manager +/- quantity buttons now sit next to each other, after the action buttons  
 - FIX: Spell immunity now compared against the spell's required level instead of the level it was cast at  
 - FIX: Spells not filtering properly when in monster lair mode with party > 1  
 - FIX: Exp/hr pasting party recognizing their class (missionary and witchunter usually)  
 - FIX: Exp/hr pasting party and inventory/mana/spellcasting going to the wrong characters  
 - FIX: Paste Character treating item stat bonuses as part of your base stats  
 - FIX: "Copy Name to Clipboard" now works when right-clicking a reference on the Sundry tab  
+- FIX: Item Manager flags now show the true quantity (e.g. "CARRIED x3") when loading a character or flagging a multi-QTY item; +/- now adjust from that count  
 
 v2.3.3 (07/15/2026)  
 ------------------------------------------------------------------------------------  

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -10,7 +10,7 @@ v2.3.4 (08/##/2026)
 - FIX: Exp/hr pasting party and inventory/mana/spellcasting going to the wrong characters  
 - FIX: Paste Character treating item stat bonuses as part of your base stats  
 - FIX: "Copy Name to Clipboard" now works when right-clicking a reference on the Sundry tab  
-- FIX: Item Manager flags now show the true quantity (e.g. "CARRIED x3") when loading a character or flagging a multi-QTY item; +/- now adjust from that count  
+- FIX: Saved Item Manager rows now reflect proper QTY and fixed adjusting QTY of pasted items  
 
 v2.3.3 (07/15/2026)  
 ------------------------------------------------------------------------------------  

--- a/frmMain.frm
+++ b/frmMain.frm
@@ -39423,6 +39423,7 @@ For Each oLI In lvItemManager.ListItems
                 sArr() = Split(oLI.ListSubItems(2), " x")
                 If UBound(sArr) >= 1 Then y = val(sArr(1))
             End If
+            If y < 1 Then y = 1
             str = str & oLI.Text & "|" & y & ","
             Set oLI = Nothing
             x = x + 1
@@ -39442,6 +39443,7 @@ For Each oLI In lvItemManager.ListItems
                 sArr() = Split(oLI.ListSubItems(2), " x")
                 If UBound(sArr) >= 1 Then y = val(sArr(1))
             End If
+            If y < 1 Then y = 1
             str = str & oLI.Text & "|" & y & ","
             Set oLI = Nothing
             x = x + 1

--- a/frmMain.frm
+++ b/frmMain.frm
@@ -15244,9 +15244,9 @@ Begin VB.Form frmMain
             EndProperty
             Height          =   375
             Index           =   17
-            Left            =   8400
+            Left            =   8040
             Style           =   1  'Graphical
-            TabIndex        =   1312
+            TabIndex        =   1311
             Top             =   240
             Width           =   855
          End
@@ -15263,9 +15263,9 @@ Begin VB.Form frmMain
             EndProperty
             Height          =   375
             Index           =   11
-            Left            =   7320
+            Left            =   6960
             Style           =   1  'Graphical
-            TabIndex        =   1311
+            TabIndex        =   1310
             Top             =   240
             Width           =   1095
          End
@@ -15304,9 +15304,9 @@ Begin VB.Form frmMain
             EndProperty
             Height          =   375
             Index           =   10
-            Left            =   6000
+            Left            =   5640
             Style           =   1  'Graphical
-            TabIndex        =   1310
+            TabIndex        =   1309
             Top             =   240
             Width           =   1335
          End
@@ -15323,9 +15323,9 @@ Begin VB.Form frmMain
             EndProperty
             Height          =   375
             Index           =   9
-            Left            =   4740
+            Left            =   4380
             Style           =   1  'Graphical
-            TabIndex        =   1309
+            TabIndex        =   1308
             Top             =   240
             Width           =   1275
          End
@@ -15342,9 +15342,9 @@ Begin VB.Form frmMain
             EndProperty
             Height          =   375
             Index           =   15
-            Left            =   4380
+            Left            =   8880
             Style           =   1  'Graphical
-            TabIndex        =   1308
+            TabIndex        =   1312
             ToolTipText     =   "Minus"
             Top             =   240
             Width           =   375
@@ -19839,8 +19839,6 @@ Select Case Index
                         If InStr(1, lvItemManager.ListItems(x).ListSubItems(2), " x", vbTextCompare) > 0 Then
                             sArr() = Split(lvItemManager.ListItems(x).ListSubItems(2), " x")
                             If UBound(sArr) >= 1 Then y = val(sArr(1))
-                        ElseIf val(lvItemManager.ListItems(x).ListSubItems(3)) > 1 Then
-                            y = val(lvItemManager.ListItems(x).ListSubItems(3))
                         End If
                         If y < 1 Then y = 1
                         nEncum = nEncum + (val(lvItemManager.ListItems(x).ListSubItems(5).Text) * y)
@@ -27271,8 +27269,6 @@ If lvItemManager.ListItems.count > 0 Then
                 If InStr(1, lvItemManager.ListItems(x).ListSubItems(2), " x", vbTextCompare) > 0 Then
                     sArr() = Split(lvItemManager.ListItems(x).ListSubItems(2), " x")
                     If UBound(sArr) >= 1 Then y = val(sArr(1))
-                ElseIf val(lvItemManager.ListItems(x).ListSubItems(3)) > 1 Then
-                    y = val(lvItemManager.ListItems(x).ListSubItems(3))
                 End If
                 If y < 1 Then y = 1
                 nCarriedItemsQTY(x) = y
@@ -35777,8 +35773,6 @@ If x < 20 Or val(cmbEquip(16).ItemData(cmbEquip(16).ListIndex)) > 0 Then
                     If InStr(1, lvItemManager.ListItems(x).ListSubItems(2), " x", vbTextCompare) > 0 Then
                         sArr() = Split(lvItemManager.ListItems(x).ListSubItems(2), " x")
                         If UBound(sArr) >= 1 Then y = val(sArr(1))
-                    ElseIf val(lvItemManager.ListItems(x).ListSubItems(3)) > 1 Then
-                        y = val(lvItemManager.ListItems(x).ListSubItems(3))
                     End If
                     If y < 1 Then y = 1
                     
@@ -37459,8 +37453,6 @@ If nEncum > 0 Then
                         If InStr(1, lvItemManager.ListItems(x).ListSubItems(2), " x", vbTextCompare) > 0 Then
                             sArr() = Split(lvItemManager.ListItems(x).ListSubItems(2), " x")
                             If UBound(sArr) >= 1 Then y = val(sArr(1))
-                        ElseIf val(lvItemManager.ListItems(x).ListSubItems(3)) > 1 Then
-                            y = val(lvItemManager.ListItems(x).ListSubItems(3))
                         End If
                         If y < 1 Then y = 1
                         nEncum = nEncum - (val(lvItemManager.ListItems(x).ListSubItems(5).Text) * y)
@@ -39430,8 +39422,6 @@ For Each oLI In lvItemManager.ListItems
             If InStr(1, oLI.ListSubItems(2), " x", vbTextCompare) > 0 Then
                 sArr() = Split(oLI.ListSubItems(2), " x")
                 If UBound(sArr) >= 1 Then y = val(sArr(1))
-            ElseIf val(oLI.ListSubItems(3)) > 1 Then
-                y = val(oLI.ListSubItems(3))
             End If
             str = str & oLI.Text & "|" & y & ","
             Set oLI = Nothing
@@ -39451,8 +39441,6 @@ For Each oLI In lvItemManager.ListItems
             If InStr(1, oLI.ListSubItems(2), " x", vbTextCompare) > 0 Then
                 sArr() = Split(oLI.ListSubItems(2), " x")
                 If UBound(sArr) >= 1 Then y = val(sArr(1))
-            ElseIf val(oLI.ListSubItems(3)) > 1 Then
-                y = val(oLI.ListSubItems(3))
             End If
             str = str & oLI.Text & "|" & y & ","
             Set oLI = Nothing

--- a/modItemParse.bas
+++ b/modItemParse.bas
@@ -81,6 +81,7 @@ Option Base 0
 ' • ListView helpers:
 '     LV_AssignRowSeqIfMissing(ByRef lv As ListView, ByRef li As ListItem)
 '     ParseActionAndQty(ByVal sFlag As String, ByRef sAction As String, ByRef nQty As Long) ' in modListViewExt
+'       Optional 4th arg nFieldQTY As Long seeds nQty when sFlag has no " xN" suffix (bare flag = 1)
 '
 ' • UI/Forms:
 '     frmMain.lvItemManager (ListView target)
@@ -1120,18 +1121,20 @@ Private Function SumInvOrCarriedQtyForName(ByRef lv As ListView, ByVal itemName 
             
             src = UCase$(SafeSubText(li, 4))
             If Left(src, Len("INVENTORY")) = "INVENTORY" Then
+                ' one physical stack per row: an Inventory row's qty lives in the QTY column, so a
+                ' CARRIED flag on that same row must NOT be added again by the branch below
                 q = val(SafeSubText(li, 3))
                 If q > 0 Then SumInvOrCarriedQtyForName = SumInvOrCarriedQtyForName + q
-            End If
-            
-            src = UCase$(SafeSubText(li, 2))
-            If Left(src, Len("CARRIED")) = "CARRIED" Then
-                If LCase(mid(src, Len("CARRIED") + 1, 2)) = " x" Then
-                    q = val(mid(src, Len("CARRIED") + 3, 999))
-                Else
-                    q = 1
+            Else
+                src = UCase$(SafeSubText(li, 2))
+                If Left(src, Len("CARRIED")) = "CARRIED" Then
+                    If LCase(mid(src, Len("CARRIED") + 1, 2)) = " x" Then
+                        q = val(mid(src, Len("CARRIED") + 3, 999))
+                    Else
+                        q = 1
+                    End If
+                    If q > 0 Then SumInvOrCarriedQtyForName = SumInvOrCarriedQtyForName + q
                 End If
-                If q > 0 Then SumInvOrCarriedQtyForName = SumInvOrCarriedQtyForName + q
             End If
             
         End If
@@ -1374,6 +1377,8 @@ Private Sub AddOneRow(ByRef lv As ListView, ByRef hit As ItemMatch, ByVal sectio
     oLI.Text = CStr(hit.Number)                                  ' Col 1: Number
 
     oLI.ListSubItems.Add 1, "Name", hit.name                     ' Col 2
+    ' NOTE: the LenB(sFlagBase) guard is load-bearing - a blank-flag row with QTY>1 would otherwise
+    '       render a headless " xN", breaking the non-flagged-row prune and sticky sort bucketing
     oLI.ListSubItems.Add 2, "Flag", IIf(LenB(sFlagBase) = 0, "", sFlagBase & IIf(tmpQty > 1, " x" & CStr(tmpQty), ""))
     oLI.ListSubItems.Add 3, "QTY", CStr(qty)                     ' Col 4
     oLI.ListSubItems.Add 4, "Source", sectionName                ' Col 5
@@ -1766,7 +1771,7 @@ End Function
 '   • Numeric sort tag for Value column matches your existing behavior (nCopperSell or 0).
 '   • Skips items not found or not gettable ([Gettable]=0), matching your other import paths.
 Public Sub LV_AddRowByItemNumber(ByVal nItemNumber As Long, Optional ByVal sSource As String, _
-    Optional ByVal sFlag As String, Optional ByVal nQTY As Integer, _
+    Optional ByVal sFlag As String, Optional ByVal nQTY As Long, _
     Optional ByVal nForceShop As Long)
 On Error GoTo error:
 

--- a/modItemParse.bas
+++ b/modItemParse.bas
@@ -1129,7 +1129,7 @@ Private Function SumInvOrCarriedQtyForName(ByRef lv As ListView, ByVal itemName 
                 If LCase(mid(src, Len("CARRIED") + 1, 2)) = " x" Then
                     q = val(mid(src, Len("CARRIED") + 3, 999))
                 Else
-                    q = val(SafeSubText(li, 3))
+                    q = 1
                 End If
                 If q > 0 Then SumInvOrCarriedQtyForName = SumInvOrCarriedQtyForName + q
             End If
@@ -1367,14 +1367,14 @@ Private Sub AddOneRow(ByRef lv As ListView, ByRef hit As ItemMatch, ByVal sectio
     End If
     
     Dim sFlagBase As String, tmpQty As Long
-    Call ParseActionAndQty(NzStr(sFlag), sFlagBase, tmpQty) ' lives in modListViewExt
+    Call ParseActionAndQty(NzStr(sFlag), sFlagBase, tmpQty, qty) ' seed suffix from row QTY; lives in modListViewExt
     
     Set oLI = lv.ListItems.Add()
     Call LV_AssignRowSeqIfMissing(lv, oLI)
     oLI.Text = CStr(hit.Number)                                  ' Col 1: Number
 
     oLI.ListSubItems.Add 1, "Name", hit.name                     ' Col 2
-    oLI.ListSubItems.Add 2, "Flag", sFlagBase & IIf(tmpQty > 1, " x" & CStr(tmpQty), "")
+    oLI.ListSubItems.Add 2, "Flag", IIf(LenB(sFlagBase) = 0, "", sFlagBase & IIf(tmpQty > 1, " x" & CStr(tmpQty), ""))
     oLI.ListSubItems.Add 3, "QTY", CStr(qty)                     ' Col 4
     oLI.ListSubItems.Add 4, "Source", sectionName                ' Col 5
     oLI.ListSubItems.Add 5, "Enc", CStr(encum)                   ' Col 6

--- a/modListViewExt.bas
+++ b/modListViewExt.bas
@@ -47,14 +47,14 @@ Public Const CLR_SAVED_LIST As Long = &HCC0085   'RGB(133, 0, 204)
 ' • LV_SetActionCell(lv, actionIndex)
 '     - Toggles/adjusts the action text in SubItem(2) for ALL selected rows:
 '         9 = cycle DROP/HIDE/clear
-'        10 = toggle PICKUP
-'        11 = cycle SELL?BUY?clear (qty preserved only where applicable)
-'        12 = toggle CARRIED   (no quantity)
+'        10 = cycle PICKUP/USE/clear
+'        11 = cycle SELL/BUY/clear (qty preserved)
+'        12 = toggle CARRIED   (qty via +/-)
 '        17 = toggle STASH     (quantity allowed)
-'        15 = decrement quantity for DROP/HIDE/BUY/SELL/PICKUP/STASH (min 1)
-'        16 = increment quantity for DROP/HIDE/BUY/SELL/PICKUP/STASH
+'        15 = decrement quantity for DROP/HIDE/BUY/SELL/PICKUP/USE/STASH/CARRIED (min 1, bare word at 1)
+'        16 = increment quantity for DROP/HIDE/BUY/SELL/PICKUP/USE/STASH/CARRIED
 '        18 = clear
-'     - Automatically sets bPromptSave when CARRIED is added/removed and calls frmMain.RefreshAll.
+'     - Automatically sets bPromptSave when CARRIED or STASH changes; calls frmMain.RefreshAll for CARRIED.
 '
 ' • LV_CopySelectedActionsToClipboard(lv)
 '     - Converts selected rows’ actions to game commands (drop/hide/sell/buy/get/stash) and copies
@@ -63,7 +63,7 @@ Public Const CLR_SAVED_LIST As Long = &HCC0085   'RGB(133, 0, 204)
 '
 ' • LV_DeleteSelected(lv)
 '     - Deletes selected rows with confirmation (when >1). Preserves a sensible selection after
-'       deletion. Triggers character save prompt + frmMain.RefreshAll if any CARRIED was affected.
+'       deletion. Triggers character save prompt if a CARRIED/STASH row was deleted (+ frmMain.RefreshAll for CARRIED).
 '
 ' • LV_InvertSelection(lv)
 '     - Inverts the Selected state for all rows.
@@ -351,6 +351,7 @@ On Error GoTo error:
     Dim targetNewIndex As Long
     Dim resp As VbMsgBoxResult
     Dim bCarriedAddedOrRemoved As Boolean
+    Dim bStashChanged As Boolean
     
     If lvListView Is Nothing Then Exit Sub
     If lvListView.ListItems.count = 0 Then Exit Sub
@@ -387,14 +388,15 @@ On Error GoTo error:
         If lvListView.ListItems(i).Selected Then
             If lvListView.ListItems(i).ListSubItems.count >= 2 Then
                 If InStr(1, lvListView.ListItems(i).ListSubItems(2).Text, "CARRIED", vbTextCompare) > 0 Then bCarriedAddedOrRemoved = True
+                If InStr(1, lvListView.ListItems(i).ListSubItems(2).Text, "STASH", vbTextCompare) > 0 Then bStashChanged = True
             End If
             lvListView.ListItems.Remove i
         End If
     Next i
     
-    If bCarriedAddedOrRemoved Then
+    If bCarriedAddedOrRemoved Or bStashChanged Then
         If bCharLoaded And Not bStartup Then bPromptSave = True
-        Call frmMain.RefreshAll
+        If bCarriedAddedOrRemoved Then Call frmMain.RefreshAll
     End If
     
     ' If nothing remains, we're done
@@ -457,6 +459,7 @@ On Error GoTo done
     Dim qty As Long, QTYfield As Long
     Dim anySelected As Boolean
     Dim bCarriedAddedOrRemoved As Boolean
+    Dim bStashChanged As Boolean
     Dim nEnc As Long, q As Integer
     
     If lvListView Is Nothing Then Exit Sub
@@ -477,10 +480,6 @@ On Error GoTo done
             curText = Trim$(li.ListSubItems(2).Text)
             Call ParseActionAndQty(curText, baseAction, qty) ' qty>=1 on return; bare flag = qty 1
             If LenB(baseAction) = 0 And QTYfield > 1 Then qty = QTYfield ' blank flag: seed new action's qty from QTY column
-            
-            If actionIndex > 0 Then
-                If actionIndex = 12 Or baseAction = "CARRIED" Then bCarriedAddedOrRemoved = True
-            End If
             
             Select Case actionIndex
                 Case 9      ' DROP/HIDE/<clear> cycle
@@ -520,7 +519,7 @@ On Error GoTo done
                         newText = "CARRIED" & IIf(qty > 1, " x" & CStr(qty), "")
                     End If
 
-                Case 17     ' STASH toggle (qty allowed via +/- later)
+                Case 17     ' STASH toggle
                     If baseAction = "STASH" Then
                         newText = ""                                  ' clear
                         ' (shop repopulation intentionally removed)
@@ -558,25 +557,29 @@ On Error GoTo done
                     GoTo nextItem
             End Select
             
-            If baseAction <> "CARRIED" And Left$(newText, 7) = "CARRIED" Then
-                nEnc = GetItemWeight(val(li.Text))
-                If nEnc > 0 And val(frmMain.txtInvenAddWeight.Text) >= (nEnc * qty) And InStr(1, li.ListSubItems(4).Text, "Inventory", vbTextCompare) > 0 Then
-                    q = MsgBox("Subtract " & li.ListSubItems(1).Text & "'s encumbrance from the 'Additional Item Weight' field on EQ tab? e.g. Is its weight currently included in that value?" & vbCrLf & vbCrLf _
-                            & "If you recently did a 'Paste Character' (different from 'Paste Items' here) where this item was in your inventory, then you probably want to answer yes." & vbCrLf & vbCrLf _
-                            & "Carried items are counted in the encumbrance calculation along with equipped items. If you answer no and it's currently included in the additional weight field, it will effectively be calculated twice, putting your calculated encumbrance over what it should be.", vbYesNo + vbDefaultButton1 + vbQuestion)
-                    If q = vbYes Then frmMain.txtInvenAddWeight.Text = val(frmMain.txtInvenAddWeight.Text) - (nEnc * qty)
+            If newText <> curText Then
+                If actionIndex = 12 Or baseAction = "CARRIED" Then bCarriedAddedOrRemoved = True
+                If actionIndex = 17 Or baseAction = "STASH" Then bStashChanged = True
+                If baseAction <> "CARRIED" And Left$(newText, 7) = "CARRIED" Then
+                    nEnc = GetItemWeight(val(li.Text))
+                    If nEnc > 0 And val(frmMain.txtInvenAddWeight.Text) >= (nEnc * qty) And InStr(1, li.ListSubItems(4).Text, "Inventory", vbTextCompare) > 0 Then
+                        q = MsgBox("Subtract " & li.ListSubItems(1).Text & "'s encumbrance from the 'Additional Item Weight' field on EQ tab? e.g. Is its weight currently included in that value?" & vbCrLf & vbCrLf _
+                                & "If you recently did a 'Paste Character' (different from 'Paste Items' here) where this item was in your inventory, then you probably want to answer yes." & vbCrLf & vbCrLf _
+                                & "Carried items are counted in the encumbrance calculation along with equipped items. If you answer no and it's currently included in the additional weight field, it will effectively be calculated twice, putting your calculated encumbrance over what it should be.", vbYesNo + vbDefaultButton1 + vbQuestion)
+                        If q = vbYes Then frmMain.txtInvenAddWeight.Text = val(frmMain.txtInvenAddWeight.Text) - (nEnc * qty)
+                    End If
                 End If
+                li.ListSubItems(2).Text = newText
             End If
-            li.ListSubItems(2).Text = newText
         End If
 nextItem:
     Next i
 
     If anySelected Then lvListView.SetFocus
 done:
-    If bCarriedAddedOrRemoved Then
+    If bCarriedAddedOrRemoved Or bStashChanged Then
         If bCharLoaded And Not bStartup Then bPromptSave = True
-        Call frmMain.RefreshAll
+        If bCarriedAddedOrRemoved Then Call frmMain.RefreshAll
     End If
     Exit Sub
 ErrHandler:
@@ -658,6 +661,8 @@ End Sub
 '--- helper: parse action + optional trailing quantity "x#"
 '--- helper: parse action + optional trailing quantity "x#"
 '--- helper: parse action + optional trailing quantity "x#"
+'--- optional nFieldQTY seeds qtyOut when the flag has no " xN" suffix (used at row creation to
+'    render the suffix from the QTY column); when omitted, a bare flag parses as qty 1
 Public Sub ParseActionAndQty(ByVal sIn As String, ByRef actionOut As String, ByRef qtyOut As Long, Optional ByVal nFieldQTY As Long)
     Dim s As String, pos As Long, tail As String, maybeNum As String
     s = Trim$(sIn)

--- a/modListViewExt.bas
+++ b/modListViewExt.bas
@@ -447,7 +447,7 @@ End Sub
 '--- UPDATED: apply action to SubItem(2), with +/- quantity handling for indices 15/16
 '--- UPDATED: apply action to SubItem(2) (main action) and SubItem(10) (CARRIED/STASH),
 '             with +/- quantity handling for indices 15/16 (incl. PICKUP now)
-'--- UPDATED: all actions in SubItem(2); +/- qty for DROP/HIDE/SELL/PICKUP/STASH; CARRIED no qty
+'--- UPDATED: all actions in SubItem(2); +/- qty for all actions; flag " xN" suffix is qty source of truth (bare = 1)
 Public Sub LV_SetActionCell(ByRef lvListView As ListView, ByVal actionIndex As Long)
 On Error GoTo done
     Dim i As Long
@@ -475,7 +475,8 @@ On Error GoTo done
             
             QTYfield = val(li.ListSubItems(3).Text)
             curText = Trim$(li.ListSubItems(2).Text)
-            Call ParseActionAndQty(curText, baseAction, qty, QTYfield) ' qty>=1 on return
+            Call ParseActionAndQty(curText, baseAction, qty) ' qty>=1 on return; bare flag = qty 1
+            If LenB(baseAction) = 0 And QTYfield > 1 Then qty = QTYfield ' blank flag: seed new action's qty from QTY column
             
             If actionIndex > 0 Then
                 If actionIndex = 12 Or baseAction = "CARRIED" Then bCarriedAddedOrRemoved = True
@@ -484,17 +485,17 @@ On Error GoTo done
             Select Case actionIndex
                 Case 9      ' DROP/HIDE/<clear> cycle
                     Select Case baseAction
-                        Case "DROP":   newText = "HIDE"
+                        Case "DROP":   newText = "HIDE" & IIf(qty > 1, " x" & CStr(qty), "")
                         Case "HIDE":   newText = ""                  ' clear (qty discarded)
-                        Case Else:     newText = "DROP"
+                        Case Else:     newText = "DROP" & IIf(qty > 1, " x" & CStr(qty), "")
                     End Select
                     
                     
                 Case 10     ' PICKUP/USE/<clear> cycle
                     Select Case baseAction
-                        Case "PICKUP": newText = "USE"
+                        Case "PICKUP": newText = "USE" & IIf(qty > 1, " x" & CStr(qty), "")
                         Case "USE":    newText = ""                  ' clear (qty discarded)
-                        Case Else:     newText = "PICKUP"
+                        Case Else:     newText = "PICKUP" & IIf(qty > 1, " x" & CStr(qty), "")
                     End Select
 
                     
@@ -505,18 +506,18 @@ On Error GoTo done
 '                        newText = "SELL"
 '                    End If
                     Select Case baseAction
-                        Case "SELL":   newText = "BUY"
+                        Case "SELL":   newText = "BUY" & IIf(qty > 1, " x" & CStr(qty), "")
                         Case "BUY":    newText = ""                  ' clear (qty discarded)
-                        Case Else:     newText = "SELL"
+                        Case Else:     newText = "SELL" & IIf(qty > 1, " x" & CStr(qty), "")
                     End Select
                     
-                Case 12     ' CARRIED toggle (no qty)
+                Case 12     ' CARRIED toggle
                     If baseAction = "CARRIED" Then
                         newText = ""                                  ' clear
                         ' (shop repopulation intentionally removed)
                         ' li.ListSubItems(2).Text = GetShopRoomNames(Val(li.Text), , bHideRecordNumbers)
                     Else
-                        newText = "CARRIED"
+                        newText = "CARRIED" & IIf(qty > 1, " x" & CStr(qty), "")
                     End If
 
                 Case 17     ' STASH toggle (qty allowed via +/- later)
@@ -525,14 +526,14 @@ On Error GoTo done
                         ' (shop repopulation intentionally removed)
                         ' li.ListSubItems(2).Text = GetShopRoomNames(Val(li.Text), , bHideRecordNumbers)
                     Else
-                        newText = "STASH"
+                        newText = "STASH" & IIf(qty > 1, " x" & CStr(qty), "")
                     End If
 
                 Case 15     ' minus: adjust qty for DROP/HIDE/SELL/PICKUP/STASH
                     Select Case baseAction
                         Case "DROP", "HIDE", "BUY", "SELL", "PICKUP", "USE", "STASH", "CARRIED"
                             If qty > 1 Then qty = qty - 1
-                            If qty <= 1 And baseAction <> "CARRIED" Then
+                            If qty <= 1 Then
                                 newText = baseAction
                             Else
                                 newText = baseAction & " x" & CStr(qty)
@@ -545,11 +546,7 @@ On Error GoTo done
                     Select Case baseAction
                         Case "DROP", "HIDE", "BUY", "SELL", "PICKUP", "USE", "STASH", "CARRIED"
                             qty = qty + 1
-                            If qty <= 1 And baseAction <> "CARRIED" Then
-                                newText = baseAction
-                            Else
-                                newText = baseAction & " x" & CStr(qty)
-                            End If
+                            newText = baseAction & " x" & CStr(qty)
                         Case Else
                             GoTo nextItem
                     End Select
@@ -561,7 +558,7 @@ On Error GoTo done
                     GoTo nextItem
             End Select
             
-            If baseAction <> "CARRIED" And newText = "CARRIED" Then
+            If baseAction <> "CARRIED" And Left$(newText, 7) = "CARRIED" Then
                 nEnc = GetItemWeight(val(li.Text))
                 If nEnc > 0 And val(frmMain.txtInvenAddWeight.Text) >= (nEnc * qty) And InStr(1, li.ListSubItems(4).Text, "Inventory", vbTextCompare) > 0 Then
                     q = MsgBox("Subtract " & li.ListSubItems(1).Text & "'s encumbrance from the 'Additional Item Weight' field on EQ tab? e.g. Is its weight currently included in that value?" & vbCrLf & vbCrLf _


### PR DESCRIPTION
This pull request makes several improvements and bug fixes to the Item Manager, focusing on more accurate and consistent quantity handling for item actions (especially "CARRIED" and "STASH"), and improves the UI layout of the +/- quantity buttons. It also cleans up logic for parsing and displaying item quantities and ensures that quantity changes are reflected correctly in both the UI and data model.

**Item Manager quantity and flag handling improvements:**

* The +/- quantity buttons in the Item Manager now sit next to each other, after the action buttons, for better usability.
* The "CARRIED" and "STASH" flags now always show the true quantity (e.g., "CARRIED x3") when loading a character or flagging a multi-quantity item; the +/- buttons now adjust from that count, and the " xN" suffix is the single source of truth for quantity. [[1]](diffhunk://#diff-59c023da8c40bbe8277d0f469e56591bf153585bf70b86c0f652240ce178044cR6-R13) [[2]](diffhunk://#diff-dc4d32b7f1d728d38c291a882ac512305db1515762d4e685d1628f2741a9c3f2L450-R452) [[3]](diffhunk://#diff-dc4d32b7f1d728d38c291a882ac512305db1515762d4e685d1628f2741a9c3f2L478-R497) [[4]](diffhunk://#diff-dc4d32b7f1d728d38c291a882ac512305db1515762d4e685d1628f2741a9c3f2L508-R535)
* The logic for parsing and displaying item quantities has been cleaned up: the code now consistently seeds the quantity from the QTY column for blank-flagged rows and avoids double-counting carried/inventory items. [[1]](diffhunk://#diff-0d35e6d5730fff49e01edc673777a5d5b4ad6ebbc1477b9ef99b8f3f2954794aR1124-R1138) [[2]](diffhunk://#diff-0d35e6d5730fff49e01edc673777a5d5b4ad6ebbc1477b9ef99b8f3f2954794aL1370-R1382)

**UI and behavior consistency:**

* The action cycling for PICKUP/USE, SELL/BUY, DROP/HIDE, CARRIED, and STASH now always preserves and displays the quantity (if >1) as a " xN" suffix, and the +/- buttons work for all actions including CARRIED and STASH. [[1]](diffhunk://#diff-dc4d32b7f1d728d38c291a882ac512305db1515762d4e685d1628f2741a9c3f2L478-R497) [[2]](diffhunk://#diff-dc4d32b7f1d728d38c291a882ac512305db1515762d4e685d1628f2741a9c3f2L508-R535)
* Deleting a row with a CARRIED or STASH flag now triggers a character save prompt, and the UI refreshes appropriately when CARRIED items are affected. [[1]](diffhunk://#diff-dc4d32b7f1d728d38c291a882ac512305db1515762d4e685d1628f2741a9c3f2R354) [[2]](diffhunk://#diff-dc4d32b7f1d728d38c291a882ac512305db1515762d4e685d1628f2741a9c3f2R391-R399) [[3]](diffhunk://#diff-dc4d32b7f1d728d38c291a882ac512305db1515762d4e685d1628f2741a9c3f2R462)

**Bug fixes:**

* Fixed bugs where the quantity for CARRIED items could be incorrect or not updated when loading a character or flagging a multi-quantity item. [[1]](diffhunk://#diff-59c023da8c40bbe8277d0f469e56591bf153585bf70b86c0f652240ce178044cR6-R13) [[2]](diffhunk://#diff-0d35e6d5730fff49e01edc673777a5d5b4ad6ebbc1477b9ef99b8f3f2954794aR1124-R1138)
* Fixed cases where blank-flagged rows with QTY>1 would render incorrectly, and ensured that the QTY column is used as a fallback only when no action flag is present.

**Minor UI adjustments:**

* Adjusted the positions and tab order of several Item Manager buttons for improved layout. [[1]](diffhunk://#diff-5a5585ab1705977a1c08bad8e7cf228e3ae2555cbc376392ba7179b75fb813c9L15247-R15249) [[2]](diffhunk://#diff-5a5585ab1705977a1c08bad8e7cf228e3ae2555cbc376392ba7179b75fb813c9L15266-R15268) [[3]](diffhunk://#diff-5a5585ab1705977a1c08bad8e7cf228e3ae2555cbc376392ba7179b75fb813c9L15307-R15309) [[4]](diffhunk://#diff-5a5585ab1705977a1c08bad8e7cf228e3ae2555cbc376392ba7179b75fb813c9L15326-R15328) [[5]](diffhunk://#diff-5a5585ab1705977a1c08bad8e7cf228e3ae2555cbc376392ba7179b75fb813c9L15345-R15347)

These changes collectively make item quantity handling more intuitive and robust for users, especially when managing carried and stashed items.