### PR TITLE
Scale weapon Extra dmg by hit chance Issue #167

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -4,6 +4,7 @@ v2.3.4 (08/##/2026)
 - UP: Armour AC/DR column now alternates between sorting by AC and by DR on repeated clicks  
 - UP: New toggle option in menu to initially always show shops first when listing item references  
 - UP: Item Manager +/- quantity buttons now sit next to each other, after the action buttons  
+- UP: Extra damage column on Weapon lists will now be reflective of hit percentage (xSwings + Extra = Avg Round)
 - FIX: Spell immunity now compared against the spell's required level instead of the level it was cast at  
 - FIX: Spells not filtering properly when in monster lair mode with party > 1  
 - FIX: Exp/hr pasting party recognizing their class (missionary and witchunter usually)  

--- a/modMain.bas
+++ b/modMain.bas
@@ -4831,7 +4831,12 @@ If nAttackTypeMUD = 4 Then 'backstab
 Else
     oLI.ListSubItems.Add (16), "xSwings", tWeaponDmg.nRoundPhysical
 End If
-oLI.ListSubItems.Add (17), "Extra", Round(tWeaponDmg.nAvgExtraSwing * tWeaponDmg.nSwings)
+If tWeaponDmg.nAvgExtraSwing > 0 And tWeaponDmg.nSwings > 0 And tWeaponDmg.nHitChance > 0 Then
+    oLI.ListSubItems.Add (17), "Extra", Round(tWeaponDmg.nAvgExtraSwing * tWeaponDmg.nSwings * (tWeaponDmg.nHitChance / 100))
+Else
+    oLI.ListSubItems.Add (17), "Extra", 0
+End If
+
 oLI.ListSubItems.Add (18), "Dmg/Rnd", tWeaponDmg.nRoundTotal
 oLI.ListSubItems.Add (19), "Dmg/1st", tWeaponDmg.nFirstRoundDamage
 oLI.ListSubItems(19).Tag = tWeaponDmg.nFirstRoundDamage + Round(tWeaponDmg.nRoundTotal / 100, 2)


### PR DESCRIPTION
Update weapon list calculations so the Extra column reflects expected per-round damage by multiplying average extra swing damage by swings and hit chance. This keeps xSwings + Extra aligned with Avg Round and avoids showing inflated extra damage when hit chance is below 100% (or zero). Added a changelog note for v2.3.4.