### PR TITLE
Show LearnSp spells in item references (Issue #165)

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -12,6 +12,7 @@ v2.3.4 (08/##/2026)
 - FIX: Paste Character treating item stat bonuses as part of your base stats  
 - FIX: "Copy Name to Clipboard" now works when right-clicking a reference on the Sundry tab  
 - FIX: Saved Item Manager rows now reflect proper QTY and fixed adjusting QTY of pasted items  
+- FIX: Spells taught by an item (LearnSp) now appear in the item's reference list  
 
 v2.3.3 (07/15/2026)  
 ------------------------------------------------------------------------------------  

--- a/modMain.bas
+++ b/modMain.bas
@@ -949,6 +949,7 @@ On Error GoTo error:
 
 DetailTB.Text = ""
 If bStartup Then Exit Sub
+LocationLV.ListItems.clear
 
 nNumber = tabItems.Fields("Number")
 
@@ -1695,7 +1696,7 @@ End If
 
 '#################
 
-Call GetLocations(tabItems.Fields("Obtained From"), LocationLV, , , nNumber, , , True)
+Call GetLocations(tabItems.Fields("Obtained From"), LocationLV, True, , nNumber, , , True)
 If Not tabItems.Fields("Number") = nNumber Then tabItems.Seek "=", nNumber
 If nNMRVer >= 1.7 Then Call GetLocations(tabItems.Fields("References"), LocationLV, True, , , , , True)
 If Not tabItems.Fields("Number") = nNumber Then tabItems.Seek "=", nNumber


### PR DESCRIPTION
Fixes #165 — LearnSp not showing up as a reference.

## Root cause

The row was being **created and then destroyed**.

`GetAbilityStats` (`modMMudFunc.bas:2290`) already handles ability 42 and already adds a correctly shaped `"Spell: …"` row to whatever ListView it is handed. But `PullItemDetail` calls it at `modMain.bas:1296`, and then at `modMain.bas:1699` calls `GetLocations` **without** `bDontClear` — which runs `lv.ListItems.clear` unconditionally (`modMain.bas:6619`, before the `Len(sLoc) < 5` early-out) and wipes it.

`PullItemDetail` never cleared the listview itself; it leaned on that `GetLocations` call to do it as a side effect.

Ability **43** (CastsSp) survives only because someone previously hit this and bolted on an explicit re-add loop afterward — the comment at `modMain.bas:1708` says so outright:

> `'this is just so it adds any references to the locationlv after being cleared from the above GetLocations`

Ability 42 never got that treatment. Neither did **122** (RemovesSpell), **151** (EndCast), **153** (KillSpell) or **160** (GiveTempSpell), which reach `GetAbilityStats` through the same `Case Else` branch.

## The fix

Two lines, matching the pattern `PullSpellDetail` already uses (clear up front at `:4212`, `bDontClear` on its `GetLocations` calls at `:4346`/`:4348`):

- `modMain.bas:952` — `LocationLV.ListItems.clear` at the top of `PullItemDetail`
- `modMain.bas:1699` — pass `True` for `bDontClear`

No new row-building code and no `GotoLocation` change: the row's `"Spell: "` prefix plus `ListSubItems(1).Tag` already route double-click to `GotoSpell`, and the row shape (`oLI.Text = ""`, `Tag` unset) is identical to the existing `"Casts: "` row so sorting is unchanged.

Because all six item reference listviews funnel through `PullItemDetail` — `lvOtherItemLoc` directly, and `lvWeaponLoc` / `lvArmourLoc` / `lvWeaponCompareLoc` / `lvArmourCompareLoc` / `lvItemManagerLoc` via `ProcessListViewClick` — one fix covers all of them.

**No duplicates introduced:** ability 43 is intercepted at `modMain.bas:1264` and never reaches `GetAbilityStats`, so its only row still comes from the re-add loop.

## Verification

Built headless (`Build of 'mudexplr.exe' succeeded`) and driven via `BM_CLICK` against `data-v1.11p.mdb` (209 items carry ability 42):

- **Repro fixed** — item 298 *scroll of shockshield* (`Abil-1=42`, `AbilVal-1=64`) now shows both `Shop: Magic Shoppe (1/398)` and `Spell: shockshield(64)`.
- **Navigation works** — double-clicking that row jumps to the Spells tab on spell 64, whose own reference box shows the reciprocal `Item: (learn) scroll of shockshield(298)`. That link was always visible from the spell side and only missing from the item side; the asymmetry is now closed.
- **No ability-43 regression** — item 835 *pristine scroll* shows exactly one `Casts: pristine scroll(450)` row, not two.
- **No stale rows** — switching items replaces the list cleanly, confirming the relocated clear still resets it.
- **Other tabs fine** — `lvWeaponLoc` populates normally (`NPC: Balthazar(263)`, one `Casts: lacerate(985)`).

Audited every `GetLocations` and `GetAbilityStats` call site: no other code path has this ordering bug. `bFullDetails` (the Item Manager path) only affects display text at `:1839`/`:1861`, so it does not gate the ability parse.

Abilities 122/151/153/160 are fixed by the same change but could not be exercised — this dataset has zero items carrying any of them, so that part is verified by inspection only.

`mudexplr.exe` is unchanged (built to a scratch `/outdir`); `README.md` is untouched since it carries released versions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
