### PR TITLE
Show a spell difficulty of 0 for learnable spells

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,5 +1,6 @@
 v2.3.4 (09/##/2026)  
 ------------------------------------------------------------------------------------  
+- UP: Spell details now show a difficulty of 0 for learnable spells instead of omitting it  
 - UP: NPC greet commands now show in the map's room references  
 - UP: Monsters will no longer show the combined lair HP in the column/table when in lair mode  
 - UP: Armour AC/DR column now alternates between sorting by AC and by DR on repeated clicks  

--- a/modMain.bas
+++ b/modMain.bas
@@ -4312,7 +4312,7 @@ Dim sSpellDetail As String, sRemoves As String, sArr() As String, x As Integer '
 Dim bCalcCombat As Boolean, bUseCharacter As Boolean
 Dim tSpellcast As tSpellCastValues, bBR As Boolean
 Dim nCastLVL As Long, sSpellEQ As String
-Dim tChar As tCharacterProfile, sBonusDamage As String, bSpellIsUsable As Boolean
+Dim tChar As tCharacterProfile, sBonusDamage As String, bSpellIsUsable As Boolean, bSpellCanBeLearned As Boolean
 
 DetailTB.Text = ""
 If bStartup Then Exit Sub
@@ -4429,7 +4429,13 @@ End If
 If Not tabSpells.Fields("Number") = nSpellNum Then tabSpells.Seek "=", nSpellNum
 
 sSpellDetail = sSpellDetail & vbCrLf & vbCrLf & "Target: " & GetSpellTargetsEnum(tabSpells.Fields("Targets"))
-If tabSpells.Fields("Diff") <> 0 And tabSpells.Fields("Diff") < 200 Then sSpellDetail = AutoAppend(sSpellDetail, "Difficulty: " & tabSpells.Fields("Diff"))
+bSpellCanBeLearned = (tabSpells.Fields("Learnable") = 1 _
+    Or (tabSpells.Fields("Magery") = 5 And bDisableKaiAutolearn = False And tabSpells.Fields("ReqLevel") > 0))
+
+'show difficulty even when it is 0, but only for spells that can actually be learned
+If tabSpells.Fields("Diff") < 200 And (tabSpells.Fields("Diff") <> 0 Or bSpellCanBeLearned) Then
+    sSpellDetail = AutoAppend(sSpellDetail, "Difficulty: " & tabSpells.Fields("Diff"))
+End If
 sSpellDetail = AutoAppend(sSpellDetail, "Attack Type: " & SpellAttackTypeEnum(tabSpells.Fields("AttType")))
 
 If nNMRVer >= 1.8 Then


### PR DESCRIPTION
`PullSpellDetail` gated the `Difficulty: N` clause on `Diff <> 0`, so a spell whose difficulty is genuinely 0 lost the text entirely — the detail line ran straight from Target to Attack Type:

```
Target: Monster or User, Attack Type: Fire, Fully-Resistable by All
```

The gate is now on learnability instead, so 0 shows for spells a character can actually learn and stays hidden for innate monster/item spells.

### The learnability test

The existing "can be learned" idiom, used in three places in the codebase, is:

```vb
Learnable = 1 Or Len([Learned From]) > 0 Or (Magery = 5 And ReqLevel > 0)
```

Querying `data-v1.11p.mdb` shows `[Learned From]` holds a single NUL byte when empty, so `Len(...) > 0` is true for all 1379 rows and that term is a no-op. Reusing the idiom here would have shown `Difficulty: 0` on all 232 zero-difficulty spells.

No spell with `Learnable = 0` has a real learn location, so this uses the test from `SpellIsUsable` (`modMMudFunc.bas:2797`) instead — trainable spells, plus Kai auto-learn when `DisableKai` isn't set. That covers 21 + 14 = 35 of the 232.

The dead `Len(...) > 0` term is left alone in the three places that already use it — out of scope here, and changing it would alter the bless-spell lists.

### Scope

The `Diff < 200` guard is untouched, so sentinel difficulties stay hidden, and nothing changes for non-zero difficulties.

### Verification

Compiles clean (`exit=0`, "Build of 'mudexplr.exe' succeeded"), built from a throwaway project copy with `/outdir` to scratch so the committed `mudexplr.exe` and the open IDE session were untouched. High-byte count and CRLF line endings verified unchanged against HEAD per the Windows-1252 rules in CLAUDE.md.

The app was **not** launched, so the rendered line is compile-verified but not eyeball-verified.

Changelog entry added under the in-progress v2.3.4 block; README isn't mirrored for that version yet, matching how the other v2.3.4 entries landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
