### PR TITLE
Monsters: add BS Defense column to lvMonsters and lvMonsterCompare

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -4,6 +4,7 @@ v2.3.4 (09/##/2026)
 - UP: Spell details now show a difficulty of 0 for learnable spells instead of omitting it  
 - UP: NPC greet commands now show in the map's room references  
 - UP: Monsters will no longer show the combined lair HP in the column/table when in lair mode  
+- UP: Monsters / Monster Compare lists now have a sortable BS Defense column (after Mag.; 1.83+ data only)  
 - UP: Armour AC/DR column now alternates between sorting by AC and by DR on repeated clicks  
 - UP: New toggle option in menu to initially always show shops first when listing item references  
 - UP: Item Manager +/- quantity buttons now sit next to each other, after the action buttons  

--- a/frmMain.frm
+++ b/frmMain.frm
@@ -32243,7 +32243,11 @@ Select Case ColumnHeader.Index
     Case Else: nSortType = ldtnumber
 End Select
 
-If ColumnHeader.Index > 2 Then bSortTag = True
+If ColumnHeader.Key = "Spell Atk." Then
+    nSortType = ldtstring
+ElseIf ColumnHeader.Index > 2 Then
+    bSortTag = True
+End If
 
 Call LV_Sort_ColumnClick(lvMonsterCompare, ColumnHeader, nSortType, bSortTag)
 
@@ -32397,9 +32401,7 @@ Select Case ColumnHeader.Index
     Case Else: nSortType = ldtnumber
 End Select
 
-If ColumnHeader.Index = 17 And nNMRVer >= 1.82 Then
-    nSortType = ldtstring
-ElseIf ColumnHeader.Index = 16 And nNMRVer < 1.82 Then
+If ColumnHeader.Key = "Spell Atk." Then
     nSortType = ldtstring
 ElseIf ColumnHeader.Index > 2 Then
     bSortTag = True
@@ -40457,8 +40459,11 @@ ElseIf nNMRVer >= 1.82 Then
     x = x + 1: lvMonsters.ColumnHeaders.Add x, "#Mobs", "#Mobs", 700, lvwColumnCenter '14
 End If
 x = x + 1: lvMonsters.ColumnHeaders.Add x, "Mag.", "Mag.", 600, lvwColumnCenter '15 (14 < 1.82)
-x = x + 1: lvMonsters.ColumnHeaders.Add x, "Undead", "Undead", 800, lvwColumnCenter '16 (15 < 1.82)
-x = x + 1: lvMonsters.ColumnHeaders.Add x, "Spell Atk.", "Spell Atk.", 1500, lvwColumnCenter '17 (16 < 1.82)
+If nNMRVer >= 1.83 Then
+    x = x + 1: lvMonsters.ColumnHeaders.Add x, "BS Defense", "BS Defense", 1100, lvwColumnCenter '16 (1.83+ only)
+End If
+x = x + 1: lvMonsters.ColumnHeaders.Add x, "Undead", "Undead", 800, lvwColumnCenter '17 (16 = 1.82, 15 < 1.82)
+x = x + 1: lvMonsters.ColumnHeaders.Add x, "Spell Atk.", "Spell Atk.", 1500, lvwColumnCenter '18 (17 = 1.82, 16 < 1.82)
 
 lvMonsterCompare.ColumnHeaders.clear
 For Each oColumnHeader In lvMonsters.ColumnHeaders

--- a/modMain.bas
+++ b/modMain.bas
@@ -6292,11 +6292,17 @@ nIndex = nIndex + 1 '15 (14 < 1.82)
 oLI.ListSubItems.Add (nIndex), "Mag.", IIf(nMagicLVL > 0, nMagicLVL, "")
 oLI.ListSubItems(nIndex).Tag = nMagicLVL
 
-nIndex = nIndex + 1 '16 (15 < 1.82)
+If nNMRVer >= 1.83 Then
+    nIndex = nIndex + 1 '16 (1.83+ only)
+    oLI.ListSubItems.Add (nIndex), "BS Defense", IIf(tabMonsters.Fields("BSDefense") > 0, tabMonsters.Fields("BSDefense"), "")
+    oLI.ListSubItems(nIndex).Tag = tabMonsters.Fields("BSDefense")
+End If
+
+nIndex = nIndex + 1 '17 (16 = 1.82, 15 < 1.82)
 oLI.ListSubItems.Add (nIndex), "Undead", IIf(tabMonsters.Fields("Undead") > 0, "X", "")
 oLI.ListSubItems(nIndex).Tag = tabMonsters.Fields("Undead")
 
-nIndex = nIndex + 1 '17 (16 < 1.82)
+nIndex = nIndex + 1 '18 (17 = 1.82, 16 < 1.82)
 If Len(tMonAtkSummary.sSpellExtraTypes) > 0 Then tMonAtkSummary.sSpellAttackTypes = tMonAtkSummary.sSpellAttackTypes & "+" & tMonAtkSummary.sSpellExtraTypes
 If Len(tMonAtkSummary.sSpellAttackTypes) > 0 Then tMonAtkSummary.sSpellAttackTypes = SortLettersWithSeparator(tMonAtkSummary.sSpellAttackTypes, "+")
 oLI.ListSubItems.Add (nIndex), "Spell Atk.", tMonAtkSummary.sSpellAttackTypes


### PR DESCRIPTION
## Summary
- Adds a sortable **BS Defense** column (`tabMonsters.BSDefense`) after "Mag." and before "Undead" on both the Monsters list and the Monster Compare list.
- Gated on NMR 1.83+ (the field does not exist in older databases), matching the existing Lair Exp / Mobs/Spwn gating.
- `lvMonsters_ColumnClick` and `lvMonsterCompare_ColumnClick` now detect the "Spell Atk." text-sort column by key instead of a hard-coded index, so the new column does not shift it. The compare list previously had no text sort for that column.
- Changelog entry added under v2.3.4.

## Verification
- Byte integrity: high-byte counts unchanged vs HEAD, CR == LF in `frmMain.frm` and `modMain.bas`.
- Both local game DBs (stock 1.11p, Paramud 1.9.1) report NMR v1.8.3, have no Null `BSDefense`, values 5..500.
- Needs a VB6 IDE build; `mudexplr.exe` not rebuilt in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
